### PR TITLE
fixed rounding error

### DIFF
--- a/src/nightlight.py
+++ b/src/nightlight.py
@@ -174,7 +174,7 @@ class NightLight:
         percentage = max(0, min(100, percentage))
 
         # Convert percentage to kelvin
-        kelvin = self._percentage_to_kelvin(percentage)
+        kelvin = round(self._percentage_to_kelvin(percentage))
 
         data = self._get_settings_data()
         if data is None:


### PR DESCRIPTION
There was a rounding bug with `set_strength`. Values [55, 56, 68] set the windows's night light to 100%. Rounding fixed it.